### PR TITLE
Enhance UI with Material 3 and responsiveness

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,13 @@ class ConservamiApp extends StatelessWidget {
       title: 'Conservami',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
-        primarySwatch: Colors.green,
+        colorSchemeSeed: Colors.green,
+        useMaterial3: true,
+      ),
+      darkTheme: ThemeData(
+        brightness: Brightness.dark,
+        colorSchemeSeed: Colors.green,
+        useMaterial3: true,
       ),
       home: HomePage(),
     );

--- a/lib/pages/add_product_page.dart
+++ b/lib/pages/add_product_page.dart
@@ -59,7 +59,7 @@ class _AddProductPageState extends State<AddProductPage> {
       appBar: AppBar(
         title: Text('Aggiungi Prodotto'),
       ),
-      body: Padding(
+      body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
         child: Form(
           key: _formKey,
@@ -95,19 +95,31 @@ class _AddProductPageState extends State<AddProductPage> {
               SizedBox(height: 16),
               Row(
                 children: [
-                  Text(
-                    _selectedDate == null
-                        ? 'Seleziona data di scadenza'
-                        : 'Scadenza: ${DateFormat('dd/MM/yyyy').format(_selectedDate!)}',
+                  Expanded(
+                    child: Text(
+                      _selectedDate == null
+                          ? 'Seleziona data di scadenza'
+                          : 'Scadenza: ${DateFormat('dd/MM/yyyy').format(_selectedDate!)}',
+                    ),
                   ),
-                  Spacer(),
-                  TextButton(
+                  OutlinedButton(
                     onPressed: () => _selectDate(context),
-                    child: Text('Scegli Data'),
+                    child: const Text('Scegli Data'),
                   )
                 ],
               ),
-              Spacer(),
+              const SizedBox(height: 24),
+              if (_imageUrl.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 24.0),
+                  child: Image.network(
+                    _imageUrl,
+                    height: 150,
+                    fit: BoxFit.cover,
+                    errorBuilder: (context, error, stackTrace) =>
+                        const Icon(Icons.fastfood, size: 100),
+                  ),
+                ),
               ElevatedButton(
                 onPressed: () async {
                   if (_formKey.currentState!.validate() && _selectedDate != null) {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -25,20 +25,51 @@ class _HomePageState extends State<HomePage> {
           if (prodotti.isEmpty) {
             return Center(child: Text('Nessun prodotto'));
           }
-          return ListView.builder(
-            itemCount: prodotti.length,
-            itemBuilder: (context, index) {
-              final prodotto = prodotti.getAt(index)!;
-              return ListTile(
-                title: Text(prodotto.nome),
-                subtitle: Text(
-                  'Scadenza: ${DateFormat('dd/MM/yyyy').format(prodotto.dataScadenza)}',
-                ),
-                trailing: IconButton(
-                  icon: Icon(Icons.delete),
-                  onPressed: () => HiveUtils.eliminaProdotto(index),
-                ),
-              );
+          return LayoutBuilder(
+            builder: (context, constraints) {
+              final isWide = constraints.maxWidth > 600;
+              final itemBuilder = (BuildContext context, int index) {
+                final prodotto = prodotti.getAt(index)!;
+                return Card(
+                  margin: const EdgeInsets.all(8),
+                  child: ListTile(
+                    leading: prodotto.immagineUrl.isNotEmpty
+                        ? Image.network(
+                            prodotto.immagineUrl,
+                            width: 50,
+                            height: 50,
+                            fit: BoxFit.cover,
+                            errorBuilder: (context, error, stackTrace) =>
+                                const Icon(Icons.fastfood),
+                          )
+                        : const Icon(Icons.fastfood),
+                    title: Text(prodotto.nome),
+                    subtitle: Text(
+                      'Scadenza: ${DateFormat('dd/MM/yyyy').format(prodotto.dataScadenza)}',
+                    ),
+                    trailing: IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () => HiveUtils.eliminaProdotto(index),
+                    ),
+                  ),
+                );
+              };
+
+              if (isWide) {
+                return GridView.builder(
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    childAspectRatio: 3.5,
+                  ),
+                  itemCount: prodotti.length,
+                  itemBuilder: itemBuilder,
+                );
+              } else {
+                return ListView.builder(
+                  itemCount: prodotti.length,
+                  itemBuilder: itemBuilder,
+                );
+              }
             },
           );
         },


### PR DESCRIPTION
## Summary
- switch to Material 3 theme and add dark mode
- modernize HomePage with responsive grid/list layout and product cards
- improve AddProductPage with scrollable form, image preview and better date picker controls

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b679ec588327bf69eef5c7c7be14