### PR TITLE
Fix notifications zone scheduling

### DIFF
--- a/lib/utils/notification_utils.dart
+++ b/lib/utils/notification_utils.dart
@@ -1,10 +1,13 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
 
 class NotificationUtils {
   static final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
       FlutterLocalNotificationsPlugin();
 
   static Future<void> initNotifications() async {
+    tz.initializeTimeZones();
     const AndroidInitializationSettings initializationSettingsAndroid =
         AndroidInitializationSettings('@mipmap/ic_launcher');
 
@@ -25,7 +28,7 @@ class NotificationUtils {
       id,
       title,
       body,
-      scheduledDate.toUtc(),
+      tz.TZDateTime.from(scheduledDate, tz.local),
       const NotificationDetails(
         android: AndroidNotificationDetails('conservami_channel', 'Conservami Notifiche',
             importance: Importance.max, priority: Priority.high),
@@ -33,7 +36,7 @@ class NotificationUtils {
       androidAllowWhileIdle: true,
       uiLocalNotificationDateInterpretation:
           UILocalNotificationDateInterpretation.absoluteTime,
-      matchDateTimeComponents: DateTimeComponents.time,
+      matchDateTimeComponents: null,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_barcode_scanner: ^2.0.0
   http: ^1.4.0
   flutter_local_notifications: ^19.2.1
+  timezone: ^0.10.1
   intl: ^0.20.2
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- initialize timezone support for notifications
- schedule notifications with TZDateTime
- add timezone dependency

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c0e96964832798617d3148abfcb6